### PR TITLE
refactor: allow json strings as parameters

### DIFF
--- a/src/models/task_meta.go
+++ b/src/models/task_meta.go
@@ -105,9 +105,9 @@ func (m *TaskMeta) CleanFields() error {
 		return fmt.Errorf("arg(script) is required")
 	}
 
-	if str.Dangerous(m.Args) {
-		return fmt.Errorf("arg(args) is dangerous")
-	}
+	// if str.Dangerous(m.Args) {
+	// 	return fmt.Errorf("arg(args) is dangerous")
+	// }
 
 	if str.Dangerous(m.Pause) {
 		return fmt.Errorf("arg(pause) is dangerous")


### PR DESCRIPTION
refactor: allow json strings as parameters

取消对参数的危险性校验，主要是考虑从n9e直接将 tagsMap和trigger_value直接组装成json字符串作为第一个参数发送给ibex，这样ibex的shell执行就能按实际事件的描述写出更灵活的逻辑。（例如是哪个文件系统报错，就清理哪个文件系统等）